### PR TITLE
feat: remove campsite via DELETE

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Campsights is a full-stack web app for discovering and sharing campsites. Users 
 - See multi-day weather forecasts for each campsite
 - Get directions to any campsite via Google Maps
 - Add new campsites with name, description, rating, coordinates, and 4WD requirement
+- Edit and delete campsites
 - Data is stored in LMDB (server) and served via REST API
 - All weather and directions UI is styled via CSS for maintainability
 - Comprehensive unit and integration tests using Vitest
@@ -196,6 +197,12 @@ npm run dev
 - **Response:**
   - Status: `200 OK`
   - Body: The updated campsite object
+
+###  `DELETE /api/v1/campsites/:id`
+- **Description:** Delete an existing campsite by ID.
+- **Response:**
+  - Status: `204 No Content`
+  - Body: N/A
 
 ## Attribution
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,6 +1,6 @@
 # Campsights Client
 
-This is the frontend for the Campsights app, built with React, Vite, and TypeScript. It allows users to view and edit campsites on an interactive map, see weather forecasts, get directions, and add new campsites with details and ratings.
+This is the frontend for the Campsights app, built with React, Vite, and TypeScript. It allows users to view, edit and delete campsites on an interactive map, see weather forecasts, get directions, and add new campsites with details and ratings.
 
 ## Tech Stack
 
@@ -16,7 +16,7 @@ This is the frontend for the Campsights app, built with React, Vite, and TypeScr
 ## Features
 
 - View campsites on a Leaflet map with interactive markers
-- Edit existing campsite data via a form on the popup
+- Edit and delete existing campsite data via a form on the popup
 - See multi-day weather forecasts for each campsite (via National Weather Service API)
 - Get directions to any campsite via Google Maps (from your current location)
 - Add new campsites with name, description, rating, coordinates, and 4WD requirement
@@ -46,5 +46,6 @@ This is the frontend for the Campsights app, built with React, Vite, and TypeScr
   - `GET /api/v1/campsites`
   - `POST /api/v1/campsites`
   - `PUT /api/v1/campsites/:id`
+  - `DELETE /api/v1/campsites/:id`
 - Weather data is fetched for each campsite and displayed in the marker popup.
 - The "Get Directions" button opens Google Maps with directions from your current location to the campsite.

--- a/packages/client/src/api/Campsites.test.ts
+++ b/packages/client/src/api/Campsites.test.ts
@@ -99,4 +99,27 @@ describe('Campsites API', () => {
                 .rejects.toThrow('Failed to update campsite: Bad Request');
         });
     });
+
+    describe('deleteCampsite', () => {
+        it('should DELETE and return true on success', async () => {
+            globalAny.fetch.mockResolvedValueOnce({
+                ok: true,
+                status: 204,
+            });
+            const result = await (await import('./Campsites')).deleteCampsite('1');
+            expect(globalAny.fetch).toHaveBeenCalledWith('/api/v1/campsites/1', expect.objectContaining({
+                method: 'DELETE',
+            }));
+            expect(result).toBe(true);
+        });
+
+        it('should throw error if DELETE fails', async () => {
+            globalAny.fetch.mockResolvedValueOnce({
+                ok: false,
+                status: 400,
+                statusText: 'Bad Request',
+            });
+            await expect((await import('./Campsites')).deleteCampsite('1')).rejects.toThrow('Failed to delete campsite: Bad Request');
+        });
+    });
 });

--- a/packages/client/src/api/Campsites.ts
+++ b/packages/client/src/api/Campsites.ts
@@ -45,3 +45,13 @@ export async function editCampsite(id: string, data: Omit<Campsite, 'id'>) {
   }
   return response.json();
 }
+
+export async function deleteCampsite(id: string) {
+  const response = await fetch(`/api/v1/campsites/${id}`, {
+    method: 'DELETE',
+  });
+  if (!response.ok && response.status !== 204) {
+    throw new Error(`Failed to delete campsite: ${response.statusText}`);
+  }
+  return true;
+}

--- a/packages/client/src/components/CampsiteMarker/CampsiteMarker.tsx
+++ b/packages/client/src/components/CampsiteMarker/CampsiteMarker.tsx
@@ -4,7 +4,7 @@ import L from "leaflet";
 import { Campsite } from "../../types/Campsite";
 import { getWeatherForecast } from "../../api/Weather";
 import { useAppDispatch, useAppSelector } from "../../store/store";
-import { putCampsite } from "../../store/campsiteSlice";
+import { putCampsite, deleteCampsite } from "../../store/campsiteSlice";
 import "./CampsiteMarker.css";
 
 interface CampsiteMarkerProps {
@@ -39,6 +39,8 @@ const CampsiteMarker: React.FC<CampsiteMarkerProps> = ({ site, renderStars }) =>
   const [editError, setEditError] = useState<string | null>(null);
   const [editLoading, setEditLoading] = useState(false);
   const [editSuccess, setEditSuccess] = useState(false);
+  const [deleteLoading, setDeleteLoading] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const popupRef = useRef<any>(null);
   const dispatch = useAppDispatch();
   const campsiteError = useAppSelector(state => state.campsites.error);
@@ -127,6 +129,23 @@ const CampsiteMarker: React.FC<CampsiteMarkerProps> = ({ site, renderStars }) =>
     }
   };
 
+  const handleDelete = async () => {
+    setDeleteLoading(true);
+    setDeleteError(null);
+    try {
+      const resultAction = await dispatch(deleteCampsite(site.id));
+      if (deleteCampsite.fulfilled.match(resultAction)) {
+        // Optionally close popup or show success
+      } else {
+        setDeleteError(resultAction.payload as string || 'Failed to delete campsite');
+      }
+    } catch (err: any) {
+      setDeleteError(err.message || 'Failed to delete campsite');
+    } finally {
+      setDeleteLoading(false);
+    }
+  };
+
   const handlePopupClose = () => {
     setEditing(false);
   };
@@ -201,7 +220,6 @@ const CampsiteMarker: React.FC<CampsiteMarkerProps> = ({ site, renderStars }) =>
                 </button>
               </div>
               {editSuccess && <div style={{ color: '#92C689', marginTop: 6, textAlign: 'center' }}>Campsite updated!</div>}
-              {/* Show Redux error if present */}
               {campsiteError && <div className="weather-error" style={{ marginTop: 2 }}>{campsiteError}</div>}
             </>
           ) : (
@@ -297,7 +315,17 @@ const CampsiteMarker: React.FC<CampsiteMarkerProps> = ({ site, renderStars }) =>
                 >
                   Cancel
                 </button>
+                <button
+                  type="button"
+                  className="popup-button"
+                  style={{ background: '#16563A', color: '#fff' }}
+                  onClick={handleDelete}
+                  disabled={deleteLoading}
+                >
+                  {deleteLoading ? 'Deleting...' : 'Delete Campsite'}
+                </button>
               </div>
+              {deleteError && <div className="weather-error" style={{ marginTop: 2 }}>{deleteError}</div>}
             </form>
           )}
         </div>

--- a/packages/client/src/store/campsiteSlice.test.ts
+++ b/packages/client/src/store/campsiteSlice.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import reducer, {
+  fetchCampsites,
+  postCampsite,
+  putCampsite,
+  deleteCampsite,
+  clearError,
+  selectCampsites,
+  selectLoading,
+  selectError,
+} from './campsiteSlice';
+import * as api from '../api/Campsites';
+import { Campsite, CampsitesState } from '../types/Campsite';
+
+vi.mock('../api/Campsites');
+
+const mockCampsite: Campsite = {
+  id: '1',
+  name: 'Test Site',
+  description: 'Test Description',
+  lat: 0,
+  lng: 0,
+  rating: 0,
+  requires_4wd: false,
+  last_updated: '',
+};
+
+const initialState: CampsitesState = {
+  campsites: [],
+  loading: false,
+  error: null,
+};
+
+describe('campsiteSlice', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('reducers', () => {
+    it('should handle clearError', () => {
+      const state = { ...initialState, error: 'Some error' };
+      const nextState = reducer(state, clearError());
+      expect(nextState.error).toBeNull();
+    });
+  });
+
+  describe('selectors', () => {
+    const state = { campsites: { ...initialState, campsites: [mockCampsite], loading: true, error: 'err' } };
+    it('selectCampsites returns campsites', () => {
+      expect(selectCampsites(state)).toEqual([mockCampsite]);
+    });
+    it('selectLoading returns loading', () => {
+      expect(selectLoading(state)).toBe(true);
+    });
+    it('selectError returns error', () => {
+      expect(selectError(state)).toBe('err');
+    });
+  });
+
+  describe('extraReducers', () => {
+    describe('fetchCampsites', () => {
+      it('handles pending', () => {
+        const action = { type: fetchCampsites.pending.type };
+        const state = reducer(initialState, action);
+        expect(state.loading).toBe(true);
+        expect(state.error).toBeNull();
+      });
+
+      it('handles fulfilled', () => {
+        const campsites = [mockCampsite];
+        const action = { type: fetchCampsites.fulfilled.type, payload: campsites };
+        const state = reducer({ ...initialState, loading: true }, action);
+        expect(state.loading).toBe(false);
+        expect(state.campsites).toEqual(campsites);
+        expect(state.error).toBeNull();
+      });
+
+      it('handles rejected', () => {
+        const action = { type: fetchCampsites.rejected.type, payload: 'Error' };
+        const state = reducer({ ...initialState, loading: true }, action);
+        expect(state.loading).toBe(false);
+        expect(state.error).toBe('Error');
+      });
+    });
+
+    describe('postCampsite', () => {
+      it('handles pending', () => {
+        const action = { type: postCampsite.pending.type };
+        const state = reducer(initialState, action);
+        expect(state.loading).toBe(true);
+        expect(state.error).toBeNull();
+      });
+
+      it('handles fulfilled', () => {
+        const action = { type: postCampsite.fulfilled.type, payload: mockCampsite };
+        const state = reducer({ ...initialState, loading: true }, action);
+        expect(state.loading).toBe(false);
+        expect(state.campsites).toContainEqual(mockCampsite);
+        expect(state.error).toBeNull();
+      });
+
+      it('handles rejected', () => {
+        const action = { type: postCampsite.rejected.type, payload: 'Error' };
+        const state = reducer({ ...initialState, loading: true }, action);
+        expect(state.loading).toBe(false);
+        expect(state.error).toBe('Error');
+      });
+    });
+
+    describe('putCampsite', () => {
+      const updatedCampsite = { ...mockCampsite, name: 'Updated' };
+      it('handles pending', () => {
+        const action = { type: putCampsite.pending.type };
+        const state = reducer(initialState, action);
+        expect(state.loading).toBe(true);
+        expect(state.error).toBeNull();
+      });
+
+      it('handles fulfilled', () => {
+        const prevState = { ...initialState, campsites: [mockCampsite], loading: true };
+        const action = { type: putCampsite.fulfilled.type, payload: updatedCampsite };
+        const state = reducer(prevState, action);
+        expect(state.loading).toBe(false);
+        expect(state.campsites[0]).toEqual(updatedCampsite);
+        expect(state.error).toBeNull();
+      });
+
+      it('handles rejected', () => {
+        const action = { type: putCampsite.rejected.type, payload: 'Error' };
+        const state = reducer({ ...initialState, loading: true }, action);
+        expect(state.loading).toBe(false);
+        expect(state.error).toBe('Error');
+      });
+    });
+
+    describe('deleteCampsite', () => {
+      it('handles pending', () => {
+        const action = { type: deleteCampsite.pending.type };
+        const state = reducer(initialState, action);
+        expect(state.loading).toBe(true);
+        expect(state.error).toBeNull();
+      });
+
+      it('handles fulfilled', () => {
+        const prevState = { ...initialState, campsites: [mockCampsite], loading: true };
+        const action = { type: deleteCampsite.fulfilled.type, payload: mockCampsite.id };
+        const state = reducer(prevState, action);
+        expect(state.loading).toBe(false);
+        expect(state.campsites).toHaveLength(0);
+        expect(state.error).toBeNull();
+      });
+
+      it('handles rejected', () => {
+        const action = { type: deleteCampsite.rejected.type, payload: 'Error' };
+        const state = reducer({ ...initialState, loading: true }, action);
+        expect(state.loading).toBe(false);
+        expect(state.error).toBe('Error');
+      });
+    });
+  });
+});

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -37,6 +37,7 @@ It provides a REST API for managing campsite data, which is stored in an LMDB da
 - `GET /api/v1/campsites` — List all campsites
 - `POST /api/v1/campsites` — Add a new campsite
 - `PUT /api/v1/campsites/:id` — Update an existing campsite
+- `DELETE /api/v1/campsites/:id` — Delete a campsite
 
 ### POST Request Format
 
@@ -69,12 +70,9 @@ Send a request to `/api/v1/campsites/{id}` (replace `{id}` with the campsite's i
 }
 ```
 
-#### Notes
-- All fields are required.
-- The `id` is taken from the URL, not the body.
-- Returns 200 and the updated campsite on success.
-- Returns 404 if the campsite does not exist.
-- Returns 400 for validation errors.
+### DELETE
+
+- `DELETE /api/v1/campsites/:id` — Delete a campsite by its unique `id`.
 
 ## Scripts
 

--- a/packages/server/src/controllers/campsitesController.ts
+++ b/packages/server/src/controllers/campsitesController.ts
@@ -136,3 +136,23 @@ export const updateCampsite = async (req: Request, res: Response) => {
     });
   }
 };
+
+export const deleteCampsite = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    if (!id || typeof id !== 'string') {
+      return res.status(400).json({ error: 'id is required and must be a string' });
+    }
+    const deleted = await campsitesService.deleteCampsite(id);
+    if (!deleted) {
+      return res.status(404).json({ error: 'Campsite not found' });
+    }
+    res.status(204).send();
+  } catch (error) {
+    console.error('Error in deleteCampsite controller:', error);
+    res.status(500).json({
+      error: 'Unable to delete campsite',
+      message: error instanceof Error ? error.message : 'Unknown error'
+    });
+  }
+};

--- a/packages/server/src/routes/campsitesRoutes.test.ts
+++ b/packages/server/src/routes/campsitesRoutes.test.ts
@@ -7,6 +7,7 @@ vi.mock('../controllers/campsitesController', () => ({
     getCampsites: vi.fn((req, res) => res.status(200).json([{ id: 1, name: 'Test Campsite' }])),
     addCampsite: vi.fn((req, res) => res.status(201).json({ id: 2, ...req.body })),
     updateCampsite: vi.fn((req, res) => res.status(200).json({ id: req.params.id, ...req.body })),
+    deleteCampsite: vi.fn((req, res) => res.status(204).json({})),
 }));
 
 const app = express();
@@ -32,5 +33,16 @@ describe('campsitesRouter', () => {
         const res = await request(app).put('/campsites/123').send(updatedCampsite);
         expect(res.status).toBe(200);
         expect(res.body).toMatchObject({ id: '123', name: 'Updated Campsite', description: 'Updated description' });
+    });
+
+    it('PUT /campsites/:id should return 404 if id is missing', async () => {
+        const res = await request(app).put('/campsites/').send({ name: 'Invalid Update' });
+        expect(res.status).toBe(404);
+    });
+
+    it('DELETE /campsites/:id should return 204', async () => {
+        const res = await request(app).delete('/campsites/123');
+        expect(res.status).toBe(204);
+        expect(res.body).toEqual({});
     });
 });

--- a/packages/server/src/routes/campsitesRoutes.ts
+++ b/packages/server/src/routes/campsitesRoutes.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { getCampsites, addCampsite, updateCampsite } from '../controllers/campsitesController';
+import { getCampsites, addCampsite, updateCampsite, deleteCampsite } from '../controllers/campsitesController';
 
 const campsitesRouter = Router();
 
@@ -13,6 +13,10 @@ campsitesRouter.post('/', (req: Request, res: Response) => {
 
 campsitesRouter.put('/:id', (req: Request, res: Response) => {
   updateCampsite(req, res);
+});
+
+campsitesRouter.delete('/:id', (req: Request, res: Response) => {
+  deleteCampsite(req, res);
 });
 
 export default campsitesRouter;

--- a/packages/server/src/services/campsitesService.ts
+++ b/packages/server/src/services/campsitesService.ts
@@ -26,18 +26,30 @@ export const addCampsite = async (campsite: Campsite): Promise<Campsite> => {
 
 export const updateCampsite = async (id: string, campsite: Campsite): Promise<Campsite | null> => {
   try {
-    // Check if campsite exists
     const existingCampsite = await db.get(id);
     if (!existingCampsite) {
       return null;
     }
     
-    // Update the campsite
     const updatedCampsite = { ...campsite, id };
     await db.put(id, updatedCampsite);
     return updatedCampsite;
   } catch (error) {
     console.error('Error updating campsite:', error);
+    throw error;
+  }
+};
+
+export const deleteCampsite = async (id: string): Promise<boolean> => {
+  try {
+    const existingCampsite = await db.get(id);
+    if (!existingCampsite) {
+      return false;
+    }
+    await db.remove(id);
+    return true;
+  } catch (error) {
+    console.error('Error deleting campsite:', error);
     throw error;
   }
 };


### PR DESCRIPTION
## Background

+ Added full backend delete functionality for campsites (service, controller, route, and tests).
+ Added frontend delete logic: API function, Redux thunk, UI integration, and tests.
+ Improved and fixed test coverage for all CRUD operations (backend and frontend), including error handling.
+ Updated README files to document DELETE endpoint and usage.