### PR TITLE
feat: db caching for elevation, fetch weather on detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ npm run dev
 - **Description:** Returns a list of all campsites.
 - **Response:**
   - Status: `200 OK`
-  - Body: Array of campsite objects with weather and elevation data attached
+  - Body: Array of campsite objects with elevation data attached
     ```json
     [
       {
@@ -162,28 +162,6 @@ npm run dev
         "requires_4wd": boolean,
         "last_updated": "ISO8601 string",
         "elevation": number,
-        "weather": [
-          {
-                "number": number,
-                "name": "string",
-                "startTime": "string",
-                "endTime": "string",
-                "isDaytime": boolean,
-                "temperature": number,
-                "temperatureUnit": "string",
-                "temperatureTrend": "string",
-                "probabilityOfPrecipitation": {
-                    "unitCode": "string",
-                    "value": number
-                },
-                "windSpeed": "string",
-                "windDirection": "string",
-                "icon": "string",
-                "shortForecast": "string",
-                "detailedForecast": "string"
-            },
-            ...
-        ] 
       },
       ...
     ]
@@ -194,6 +172,40 @@ npm run dev
 - **Response:**
   - Status: `200 OK`
   - Body: Campsite object with weather and elevation data attached
+```json
+    {
+      "id": "string",
+      "name": "string",
+      "description": "string",
+      "lat": number,
+      "lng": number,
+      "requires_4wd": boolean,
+      "last_updated": "ISO8601 string",
+      "elevation": number,
+      "weather": [
+        {
+              "number": number,
+              "name": "string",
+              "startTime": "string",
+              "endTime": "string",
+              "isDaytime": boolean,
+              "temperature": number,
+              "temperatureUnit": "string",
+              "temperatureTrend": "string",
+              "probabilityOfPrecipitation": {
+                  "unitCode": "string",
+                  "value": number
+              },
+              "windSpeed": "string",
+              "windDirection": "string",
+              "icon": "string",
+              "shortForecast": "string",
+              "detailedForecast": "string"
+          },
+          ...
+      ] 
+    }
+```
 
 ### `POST /api/v1/campsites`
 - **Description:** Add a new campsite.

--- a/packages/client/src/api/Campsites.ts
+++ b/packages/client/src/api/Campsites.ts
@@ -13,6 +13,20 @@ export const getCampsites = async (): Promise<Campsite[]> => {
   }
 }
 
+export const getCampsiteById = async (id: string): Promise<Campsite | null> => {
+  try {
+    const response = await fetch(`/api/v1/campsites/${id}`);
+    if (!response.ok) {
+      if (response.status === 404) return null; // Not found
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('Error fetching campsite by ID:', error);
+    throw error;
+  }
+};
+
 export const addCampsite = async (campsite: Campsite): Promise<Campsite> => {
   try {
     const response = await fetch('/api/v1/campsites', {

--- a/packages/client/src/components/CampsiteMarker/CampsiteMarker.css
+++ b/packages/client/src/components/CampsiteMarker/CampsiteMarker.css
@@ -1,43 +1,3 @@
-.weather-forecast-list {
-  max-height: 200px;
-  overflow-y: auto;
-  margin-top: 8px;
-}
-
-.weather-period-card {
-  background: #F2EFE9;
-  border-radius: 8px;
-  box-shadow: none;
-  margin-bottom: 10px;
-  padding: 10px 12px;
-  border-left: 4px solid #92C689;
-}
-
-.weather-period-header {
-  font-weight: 600;
-  margin-bottom: 4px;
-  color: #2a3a4a;
-}
-
-.weather-period-details {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px 16px;
-  font-size: 0.97em;
-  color: #2a3a4a;
-}
-
-.weather-period-details span {
-  min-width: 110px;
-  display: inline-block;
-}
-
-.weather-period-forecast {
-  font-style: italic;
-  color: #92C689;
-  margin-top: 4px;
-}
-
 .directions-btn-container {
   margin: 16px 0 0 0;
   display: flex;
@@ -87,16 +47,4 @@
 a.popup-button {
   color: #000 !important;
   text-decoration: none !important;
-}
-
-.weather-section {
-  margin-top: 12px;
-}
-
-.weather-loading {
-  color: #92C689;
-}
-
-.weather-error {
-  color: #92C689;
 }

--- a/packages/client/src/components/CampsiteMarker/CampsiteMarker.test.tsx
+++ b/packages/client/src/components/CampsiteMarker/CampsiteMarker.test.tsx
@@ -41,6 +41,7 @@ vi.mock('../EditCampsiteForm/EditCampsiteForm', () => ({
   ),
 }));
 
+import * as CampsitesApi from '../WeatherCard/../../api/Campsites';
 import CampsiteMarker from './CampsiteMarker';
 import { Campsite } from '../../types/Campsite';
 
@@ -83,12 +84,15 @@ const sampleSite: Campsite & { weather: any[] } = {
   last_updated: '2024-01-01T00:00:00Z',
 };
 
+vi.mock('../WeatherCard/../../api/Campsites');
+
 describe('<CampsiteMarker />', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    (CampsitesApi.getCampsiteById as any).mockResolvedValue({ weather: sampleSite.weather });
   });
 
-  it('renders marker and popup with site info', () => {
+  it('renders marker and popup with site info', async () => {
     render(<CampsiteMarker site={sampleSite} />);
 
     expect(screen.getByTestId('marker')).toBeInTheDocument();
@@ -96,8 +100,16 @@ describe('<CampsiteMarker />', () => {
     expect(screen.getByText('A lovely place')).toBeInTheDocument();
     expect(screen.getByText('100 m (328 ft)')).toBeInTheDocument();
     expect(screen.getByText('Yes')).toBeInTheDocument();
-    expect(screen.getByText('Morning (Day)')).toBeInTheDocument();
-    expect(screen.getByText('Evening (Night)')).toBeInTheDocument();
+
+    await screen.findByText((content, node) =>
+      node?.textContent?.replace(/\s+/g, '') === 'Morning(Day)'
+    );
+    expect(screen.getByText((content, node) =>
+      node?.textContent?.replace(/\s+/g, '') === 'Morning(Day)'
+    )).toBeInTheDocument();
+    expect(screen.getByText((content, node) =>
+      node?.textContent?.replace(/\s+/g, '') === 'Evening(Night)'
+    )).toBeInTheDocument();
   });
 
   it('toggles edit mode when clicking Edit Campsite button', async () => {

--- a/packages/client/src/components/CampsiteMarker/CampsiteMarker.tsx
+++ b/packages/client/src/components/CampsiteMarker/CampsiteMarker.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState, useRef, useMemo } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { Marker, Popup } from "react-leaflet";
 import L from "leaflet";
 import { Campsite } from "../../types/Campsite";
 import EditCampsiteForm from "../EditCampsiteForm/EditCampsiteForm";
+import WeatherCard from "../WeatherCard/WeatherCard";
 import "./CampsiteMarker.css";
 
 export interface CampsiteMarkerProps {
@@ -14,6 +15,7 @@ const CampsiteMarker: React.FC<CampsiteMarkerProps> = ({ site }) => {
 
   const [editing, setEditing] = useState(false);
   const popupRef = useRef<any>(null);
+  const markerRef = useRef<any>(null);
 
   const tentIcon = new L.DivIcon({
     html: `<div style="display: flex; align-items: flex-end; justify-content: center; height: 50px; width: 50px;">
@@ -37,41 +39,18 @@ const CampsiteMarker: React.FC<CampsiteMarkerProps> = ({ site }) => {
     setEditing(false);
   };
 
-  const weatherCards = useMemo(() => {
-    if (!site.weather || site.weather.length === 0) {
-      return <div className="weather-period-card">No weather data available</div>;
-    }
-    return site.weather.map((p: any) => (
-      <div key={p.number} className="weather-period-card">
-        <div className="weather-period-header">
-          {p.name} ({p.isDaytime ? "Day" : "Night"})
-        </div>
-        <div className="weather-period-details">
-          <span className="weather-temp">
-            <strong>Temp:</strong> {p.temperature}°{p.temperatureUnit}
-          </span>
-          <span className="weather-wind">
-            <strong>Wind:</strong> {p.windSpeed} {p.windDirection}
-          </span>
-          <span className="weather-short">
-            <strong>Forecast:</strong> {p.detailedForecast}
-          </span>
-        </div>
-      </div>
-    ));
-  }, [site.weather]);
-
   return (
     <Marker
       key={site.id}
       position={[site.lat, site.lng] as [number, number]}
       icon={tentIcon}
+      ref={markerRef}
     >
       <Popup
         data-testid="popup"
         ref={popupRef}
-        autoClose={false}
-        closeOnClick={false}
+        autoClose={true}
+        closeOnClick={true}
         eventHandlers={{ popupclose: handlePopupClose }}
       >
         <div>
@@ -90,9 +69,7 @@ const CampsiteMarker: React.FC<CampsiteMarkerProps> = ({ site }) => {
               </div>
               <div className="weather-section">
                 <strong>Weather Forecast:</strong>
-                <div className="weather-forecast-list">
-                  {weatherCards}
-                </div>
+                <WeatherCard campsiteId={site.id} />
               </div>
               <div className="directions-btn-container" style={{ gap: 8 }}>
                 <a

--- a/packages/client/src/components/WeatherCard/WeatherCard.css
+++ b/packages/client/src/components/WeatherCard/WeatherCard.css
@@ -1,0 +1,52 @@
+.weather-forecast-list {
+  max-height: 200px;
+  overflow-y: auto;
+  margin-top: 8px;
+}
+
+.weather-period-card {
+  background: #F2EFE9;
+  border-radius: 8px;
+  box-shadow: none;
+  margin-bottom: 10px;
+  padding: 10px 12px;
+  border-left: 4px solid #92C689;
+}
+
+.weather-period-header {
+  font-weight: 600;
+  margin-bottom: 4px;
+  color: #2a3a4a;
+}
+
+.weather-period-details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  font-size: 0.97em;
+  color: #2a3a4a;
+}
+
+.weather-period-details span {
+  min-width: 110px;
+  display: inline-block;
+}
+
+.weather-period-forecast {
+  font-style: italic;
+  color: #92C689;
+  margin-top: 4px;
+}
+
+.weather-section {
+  margin-top: 12px;
+}
+
+.weather-loading {
+  color: #92C689;
+  height: 200px;
+}
+
+.weather-error {
+  color: #92C689;
+}

--- a/packages/client/src/components/WeatherCard/WeatherCard.test.tsx
+++ b/packages/client/src/components/WeatherCard/WeatherCard.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+import WeatherCard from "./WeatherCard";
+import * as CampsitesApi from "../../api/Campsites";
+
+vi.mock("../../api/Campsites");
+
+const mockWeather = [
+    {
+        number: 1,
+        name: "Monday",
+        isDaytime: true,
+        temperature: 75,
+        temperatureUnit: "F",
+        windSpeed: "10 mph",
+        windDirection: "NW",
+        detailedForecast: "Sunny and warm.",
+    },
+    {
+        number: 2,
+        name: "Monday Night",
+        isDaytime: false,
+        temperature: 55,
+        temperatureUnit: "F",
+        windSpeed: "5 mph",
+        windDirection: "N",
+        detailedForecast: "Clear and cool.",
+    },
+];
+
+describe("WeatherCard", () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("renders loading state initially", () => {
+        (CampsitesApi.getCampsiteById as any).mockReturnValue(new Promise(() => {}));
+        render(<WeatherCard campsiteId="123" />);
+        expect(screen.getByText(/loading weather/i)).toBeInTheDocument();
+    });
+
+    it("renders weather data when fetched", async () => {
+        (CampsitesApi.getCampsiteById as any).mockResolvedValue({ weather: mockWeather });
+        render(<WeatherCard campsiteId="123" />);
+        await waitFor(() => {
+            expect(screen.getByText(/Monday \(Day\)/)).toBeInTheDocument();
+            expect(screen.getAllByText(/Temp:/)).toHaveLength(2);
+            expect(screen.getByText(/Sunny and warm/)).toBeInTheDocument();
+            expect(screen.getByText(/Monday Night \(Night\)/)).toBeInTheDocument();
+            expect(screen.getByText(/Clear and cool/)).toBeInTheDocument();
+        });
+    });
+
+    it("renders no weather data message if weather is empty", async () => {
+        (CampsitesApi.getCampsiteById as any).mockResolvedValue({ weather: [] });
+        render(<WeatherCard campsiteId="123" />);
+        await waitFor(() => {
+            expect(screen.getByText(/no weather data available/i)).toBeInTheDocument();
+        });
+    });
+
+    it("renders error message on fetch failure", async () => {
+        (CampsitesApi.getCampsiteById as any).mockRejectedValue(new Error("fail"));
+        render(<WeatherCard campsiteId="123" />);
+        await waitFor(() => {
+            expect(screen.getByText(/failed to fetch weather/i)).toBeInTheDocument();
+        });
+    });
+
+    it("renders no weather data message if weather is not an array", async () => {
+        (CampsitesApi.getCampsiteById as any).mockResolvedValue({ weather: null });
+        render(<WeatherCard campsiteId="123" />);
+        await waitFor(() => {
+            expect(screen.getByText(/no weather data available/i)).toBeInTheDocument();
+        });
+    });
+});

--- a/packages/client/src/components/WeatherCard/WeatherCard.tsx
+++ b/packages/client/src/components/WeatherCard/WeatherCard.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from "react";
+import { Campsite } from "../../types/Campsite";
+import { getCampsiteById } from "../../api/Campsites";
+import "./WeatherCard.css";
+
+interface WeatherCardProps {
+  campsiteId: string;
+}
+
+const WeatherCard: React.FC<WeatherCardProps> = ({ campsiteId }) => {
+  const [weather, setWeather] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    setLoading(true);
+    setError(null);
+    getCampsiteById(campsiteId)
+      .then((site) => {
+        if (isMounted) {
+          if (site && Array.isArray((site as any).weather)) {
+            setWeather((site as any).weather);
+          } else {
+            setWeather([]);
+          }
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (isMounted) {
+          setError("Failed to fetch weather");
+          setLoading(false);
+        }
+      });
+    return () => {
+      isMounted = false;
+    };
+  }, [campsiteId]);
+
+  if (loading) return <div className="weather-period-card weather-loading">Loading weather...</div>;
+  if (error) return <div className="weather-period-card error">{error}</div>;
+  if (!weather || weather.length === 0) {
+    return <div className="weather-period-card">No weather data available</div>;
+  }
+  return (
+    <div className="weather-forecast-list">
+      {weather.map((p: any) => (
+        <div key={p.number} className="weather-period-card">
+          <div className="weather-period-header">
+            {p.name} ({p.isDaytime ? "Day" : "Night"})
+          </div>
+          <div className="weather-period-details">
+            <span className="weather-temp">
+              <strong>Temp:</strong> {p.temperature}°{p.temperatureUnit}
+            </span>
+            <span className="weather-wind">
+              <strong>Wind:</strong> {p.windSpeed} {p.windDirection}
+            </span>
+            <span className="weather-short">
+              <strong>Forecast:</strong> {p.detailedForecast}
+            </span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default WeatherCard;

--- a/packages/server/src/services/campsites/campsitesService.test.ts
+++ b/packages/server/src/services/campsites/campsitesService.test.ts
@@ -25,19 +25,17 @@ beforeEach(async () => {
 
 describe('Campsites Service', () => {
   describe('getCampsites', () => {
-    it('should return campsites with existing elevation and fetched weather', async () => {
+    it('should return campsites with existing elevation', async () => {
       const campsite = { id: '1', lat: 10, lng: 20, elevation: 50 };
       dbMock.getRange.mockReturnValue([{ value: campsite }]);
-      const fakeWeather = [{ number: 1, name: 'Test', startTime: '', endTime: '', isDaytime: true, temperature: 70, temperatureUnit: 'F', windSpeed: '5 mph', windDirection: 'N', shortForecast: 'Sunny', detailedForecast: 'Clear skies' }];
-      getWeatherForecastMock.mockResolvedValue(fakeWeather);
+      // No weather fetching for list endpoint
 
       const result = await campsitesService.getCampsites();
 
       expect(dbMock.getRange).toHaveBeenCalled();
-      expect(getWeatherForecastMock).toHaveBeenCalledWith(campsite);
+      expect(getWeatherForecastMock).not.toHaveBeenCalled();
       expect(result).toEqual([{
-        ...campsite,
-        weather: fakeWeather
+        ...campsite
       }]);
     });
 

--- a/packages/server/src/services/campsites/campsitesService.ts
+++ b/packages/server/src/services/campsites/campsitesService.ts
@@ -35,7 +35,11 @@ export const getCampsites = async (): Promise<
     return await Promise.all(
       raw.map(async (site) => {
         const { weather } = await attachWeather(site);
-        return { ...site, elevation: site.elevation ?? null, weather };
+        let elevation = site.elevation ?? null;
+        if (elevation == null && site.lat != null && site.lng != null) {
+          elevation = await getElevation(site.lat, site.lng);
+        }
+        return { ...site, elevation, weather };
       })
     );
   } catch (err) {
@@ -52,7 +56,11 @@ export const getCampsiteById = async (
     if (!campsite) return null;
 
     const { weather } = await attachWeather(campsite);
-    return { ...campsite, elevation: campsite.elevation ?? null, weather };
+    let elevation = campsite.elevation ?? null;
+    if (elevation == null && campsite.lat != null && campsite.lng != null) {
+      elevation = await getElevation(campsite.lat, campsite.lng);
+    }
+    return { ...campsite, elevation, weather };
   } catch (err) {
     console.error('Error fetching campsite %s:', id, err);
     throw err;

--- a/packages/server/src/services/campsites/campsitesService.ts
+++ b/packages/server/src/services/campsites/campsitesService.ts
@@ -39,9 +39,7 @@ export const getCampsites = async (): Promise<
     const locations = sitesNeedingElevation.map(({ site }) => ({ latitude: site.lat, longitude: site.lng }));
     let elevations: (number | null)[] = [];
     if (locations.length > 0) {
-      console.log(`[campsitesService] Requesting batch elevations for ${locations.length} locations`);
       elevations = await getElevations(locations);
-      console.log(`[campsitesService] Received elevations:`, elevations);
     }
 
     const result = await Promise.all(
@@ -49,7 +47,6 @@ export const getCampsites = async (): Promise<
         let elevation = site.elevation ?? null;
         const batchIdx = sitesNeedingElevation.findIndex(({ idx: i }) => i === idx);
         if (batchIdx !== -1) {
-          console.log(`[campsitesService] Assigning batch elevation for site ${site.id}: ${elevations[batchIdx]}`);
           elevation = elevations[batchIdx];
         }
         return { ...site, elevation };

--- a/packages/server/src/services/elevation/elevationService.ts
+++ b/packages/server/src/services/elevation/elevationService.ts
@@ -4,7 +4,7 @@ import { db } from '../../config/db';
 
 const elevationCache = new Map<string, number | null>();
 
-const getElevations = async (
+export const getElevations = async (
   locations: { latitude: number; longitude: number }[]
 ): Promise<(number | null)[]> => {
   const keys = locations.map(({ latitude, longitude }) => `${latitude},${longitude}`);
@@ -12,26 +12,53 @@ const getElevations = async (
   const uncached: { latitude: number; longitude: number }[] = [];
   const uncachedIndexes: number[] = [];
 
+  // First, check in-memory cache
+  const dbKeysToFetch: string[] = [];
+  const dbIndexesToFetch: number[] = [];
   for (const [index, key] of keys.entries()) {
     if (elevationCache.has(key)) {
+      console.log(`[elevationService] In-memory cache hit for ${key}`);
       results[index] = elevationCache.get(key)!;
       continue;
     }
-    const dbKey = `elevation:${key}`;
-    let dbElevation: number | null | undefined = undefined;
+    dbKeysToFetch.push(`elevation:${key}`);
+    dbIndexesToFetch.push(index);
+  }
+
+  // Batch DB get for all uncached keys
+  let dbResults: (number | null | undefined)[] = [];
+  if (dbKeysToFetch.length > 0 && typeof db.getMany === 'function') {
     try {
-      dbElevation = await db.get(dbKey);
-    } catch {}
+      console.log(`[elevationService] Batch DB getMany for ${dbKeysToFetch.length} keys`);
+      dbResults = await db.getMany(dbKeysToFetch);
+    } catch {
+      dbResults = [];
+    }
+  } else if (dbKeysToFetch.length > 0) {
+    console.log(`[elevationService] Sequential DB get for ${dbKeysToFetch.length} keys`);
+    dbResults = await Promise.all(dbKeysToFetch.map(async (k) => {
+      try { return await db.get(k); } catch { return undefined; }
+    }));
+  }
+
+  // Fill results from DB batch
+  for (let i = 0; i < dbResults.length; i++) {
+    const dbElevation = dbResults[i];
+    const index = dbIndexesToFetch[i];
+    const key = keys[index];
     if (typeof dbElevation === 'number' || dbElevation === null) {
+      console.log(`[elevationService] DB cache hit for ${key}`);
       elevationCache.set(key, dbElevation);
       results[index] = dbElevation;
-      continue;
+    } else {
+      console.log(`[elevationService] Cache miss for ${key}, will fetch from API`);
+      uncached.push(locations[index]);
+      uncachedIndexes.push(index);
     }
-    uncached.push(locations[index]);
-    uncachedIndexes.push(index);
   }
 
   if (uncached.length > 0) {
+    console.log(`[elevationService] Fetching elevations for ${uncached.length} uncached locations from API`);
     let payload: { results: Elevation[] } | null = null;
     try {
       const response = await fetchWithRetry('https://api.open-elevation.com/api/v1/lookup', {
@@ -61,7 +88,11 @@ const getElevations = async (
       const elevation = payload!.results[i].elevation;
       elevationCache.set(key, elevation);
       const dbKey = `elevation:${key}`;
-      db.put(dbKey, elevation).catch(() => {});
+      db.put(dbKey, elevation).then(() => {
+        console.log(`[elevationService] Saved elevation for ${key} to DB cache`);
+      }).catch(() => {
+        console.warn(`[elevationService] Failed to save elevation for ${key} to DB cache`);
+      });
       results[uncachedIndexes[i]] = elevation;
     });
   }

--- a/packages/server/src/services/elevation/elevationService.ts
+++ b/packages/server/src/services/elevation/elevationService.ts
@@ -2,7 +2,7 @@ import { fetchWithRetry } from '../../utils/fetchWithRetry';
 import { Elevation } from '../../models/elevationModel';
 import { db } from '../../config/db';
 
-const elevationCache = new Map<string, number | null>();
+export const elevationCache = new Map<string, number | null>();
 
 export const getElevations = async (
   locations: { latitude: number; longitude: number }[]

--- a/packages/server/src/utils/fetchWithRetry.ts
+++ b/packages/server/src/utils/fetchWithRetry.ts
@@ -11,6 +11,10 @@ export async function fetchWithRetry(
     try {
       const res = await fetch(url, init);
       if (res.ok) return res;
+      if (res.status === 429) {
+        lastError = new Error(`API responded with status 429 (Too Many Requests)`);
+        break; // Stop retrying on 429
+      }
       lastError = new Error(`API responded with status ${res.status}`);
     } catch (err) {
       lastError = err instanceof Error ? err : new Error(String(err));


### PR DESCRIPTION
## Background

+ Fetch weather data only on the campsite detail endpoint `getCampsiteById`, not on the list endpoint.
+ Updated frontend to fetch and display weather on demand via the `WeatherCard` component.
+ Added/optimized in-memory and database (LMDB) caching for elevation lookups, including batch DB gets for multiple sites.
+ Ensured elevation is only fetched from the API if not present in cache or DB, reducing redundant external calls.
+ Updated backend and frontend tests to reflect new weather-fetching and elevation-caching logic.
+ Improved error handling and test reliability for all elevation and weather fetch scenarios.