### PR TITLE
refactor: docker builder / runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,11 @@ Campsights uses the [National Weather Service (NWS) API](https://www.weather.gov
 
 Campsights is designed for speed, efficiency, and resilience:
 
+- **Cluster Architecture:**
+  - Node.js cluster mode is used to fully utilize all CPU cores by running multiple worker processes in parallel.
+  - Each worker handles its own set of requests, increasing throughput and reducing response times under heavy load.
+  - The master process automatically restarts any worker that crashes or becomes unresponsive, ensuring high availability and fault tolerance.
+  - In-memory caches are per worker, so cache hits are local to each process, but this tradeoff is outweighed by the scalability and resilience benefits of clustering.
 - **Two-Tier Data Loading:**
   - The list endpoint (`GET /api/v1/campsites`) returns raw BLM data instantly, without elevation or weather, for maximum speed and minimal API usage.
   - The detail endpoint (`GET /api/v1/campsites/:id`) fetches and caches elevation and weather only when a specific campsite is requested, keeping the list view fast and the detail view rich.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,14 @@ services:
   app:
     build:
       context: .
+      dockerfile: Dockerfile
+      target: runner
     container_name: campsights-app
     ports:
       - "4000:4000"
     environment:
       NODE_ENV: development
       PORT: 4000
+    volumes:
+      - ./packages:/app/packages:ro 
+    restart: unless-stopped


### PR DESCRIPTION
## Background

Defined a single service named app that:
+ Builds from the local Dockerfile using the runner target.
+ Exposes port 4000 on the host and container.
+ Sets environment variables: NODE_ENV=development and PORT=4000.
+ Mounts the packages directory into the container at /app/packages as read-only.
+ Uses restart: unless-stopped for resilience.