### PR TITLE
feat: cors allowed origins

### DIFF
--- a/packages/server/openapi.yaml
+++ b/packages/server/openapi.yaml
@@ -2,8 +2,11 @@ openapi: 3.0.3
 info:
   title: Campsights API
   version: 2.0.0
+
   description: |
     API for Campsights app - provides campsite data from the Bureau of Land Management (BLM) Spider API with enhanced elevation and weather information.
+
+    **CORS access is restricted:** Only requests from the official production and development frontend origins are allowed (https://campsights.onrender.com, http://localhost:5173 and http://localhost:4000).
 
     ## Data Sources
     - **Campsites**: Bureau of Land Management Spider API (https://blm-spider.onrender.com/api/v1/campsites)
@@ -56,6 +59,8 @@ paths:
                 source: "BLM"
         '400':
           $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '429':
           $ref: '#/components/responses/TooManyRequests'
         '500':
@@ -79,6 +84,8 @@ paths:
                 $ref: '#/components/schemas/CampsiteWithWeather'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
         '429':
@@ -279,6 +286,12 @@ components:
             $ref: '#/components/schemas/Error'
     NotFound:
       description: Not Found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Forbidden:
+      description: Forbidden - Invalid Origin or not allowed
       content:
         application/json:
           schema:

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -82,6 +82,14 @@ describe('server', () => {
         expect([200, 404]).toContain(res.status);
     });
 
+    it('should reject API requests with an invalid Origin header', async () => {
+        const res = await request(app)
+            .get('/api/v1/campsites')
+            .set('Origin', 'https://malicious-site.com');
+        expect(res.status).toBe(403);
+        expect(res.body).toHaveProperty('error', 'API access denied: invalid origin');
+    });
+
     describe('static file serving', () => {
         beforeEach(async () => {
             const { default: fsMock } = await import('fs/promises');

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -12,7 +12,6 @@ dotenv.config();
 const swaggerDocument = YAML.load(__dirname + '/../openapi.yaml');
 
 export function server() {
-
   const app = express();
   app.set('trust proxy', 1); 
 
@@ -62,7 +61,7 @@ export function server() {
   });
 
   app.use(globalLimiter);
-  app.use('/api/v1/campsites', campsitesRouter);
+
   app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
   app.get('/health', (req, res) => {
@@ -81,7 +80,6 @@ export function server() {
 
   const staticPath = path.join(__dirname, "../client/dist");
   const indexHtmlPath = path.join(staticPath, "index.html");
-
 
   fs.access(indexHtmlPath)
     .then(() => {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -12,11 +12,46 @@ dotenv.config();
 const swaggerDocument = YAML.load(__dirname + '/../openapi.yaml');
 
 export function server() {
+
   const app = express();
   app.set('trust proxy', 1); 
 
-  app.use(cors());
+  const allowedOrigins = [
+    'https://campsights.onrender.com',
+    'http://localhost:5173',
+    'http://localhost:4000'
+  ];
+
+  app.use(cors({
+    origin: function (origin, callback) {
+      if (!origin) return callback(null, true);
+      if (allowedOrigins.includes(origin)) {
+        return callback(null, true);
+      }
+      const err = new Error('API access denied: invalid origin');
+      (err as any).status = 403;
+      return callback(err);
+    },
+    credentials: true
+  }));
+
   app.use(express.json());
+
+  function apiOriginCheck(req: express.Request, res: express.Response, next: express.NextFunction) {
+    const origin = req.get('origin');
+    const referer = req.get('referer');
+    const allowed = allowedOrigins.some(o =>
+      (origin && origin.startsWith(o)) ||
+      (referer && referer.startsWith(o))
+    );
+    if (!allowed && origin) {
+      res.status(403).json({ error: 'API access denied: invalid origin' });
+      return;
+    }
+    next();
+  }
+
+  app.use('/api/v1/campsites', apiOriginCheck, campsitesRouter);
 
   const globalLimiter = rateLimit({
     windowMs: 60 * 1000,
@@ -40,7 +75,8 @@ export function server() {
 
   app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
     console.error("Unhandled error:", err);
-    res.status(err.status || 500).json({ error: err.message || "Internal Server Error" });
+    const status = err.status || err.statusCode || 500;
+    res.status(status).json({ error: err.message || "Internal Server Error" });
   });
 
   const staticPath = path.join(__dirname, "../client/dist");


### PR DESCRIPTION
## Background

+ Restricted CORS to only allow requests from the official production and development frontend origins (https://campsights.onrender.com, http://localhost:5173, and http://localhost:4000).
+ Added explicit middleware to block API requests with invalid Origin or Referer headers, returning a 403 error for unauthorized access.