### PR TITLE
refactor: getCampsiteById redux

### DIFF
--- a/packages/client/src/App.css
+++ b/packages/client/src/App.css
@@ -4,7 +4,8 @@ html,
 body,
 #root,
 .app-container {
-  height: 100%;
+  height: 100vh;
+  width: 100vw;
   margin: 0;
   padding: 0;
   min-width: 0;

--- a/packages/client/src/components/CampsiteMarker/CampsiteMarker.tsx
+++ b/packages/client/src/components/CampsiteMarker/CampsiteMarker.tsx
@@ -2,7 +2,8 @@ import React, { useRef, useState } from "react";
 import { Marker, Popup } from "react-leaflet";
 import L from "leaflet";
 import { Campsite } from "../../types/Campsite";
-import { getCampsiteById } from "../../api/Campsites";
+import { fetchCampsiteById } from "../../store/campsiteSlice";
+import { useDispatch } from "react-redux";
 import WeatherCard from "../WeatherCard/WeatherCard";
 import "./CampsiteMarker.css";
 
@@ -13,24 +14,24 @@ export interface CampsiteMarkerProps {
 
 const CampsiteMarker: React.FC<CampsiteMarkerProps> = ({ site, map }) => {
   if (!site) return null;
-
   const popupRef = useRef<any>(null);
   const markerRef = useRef<any>(null);
   const [enrichedSite, setEnrichedSite] = useState<Campsite | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showFullDescription, setShowFullDescription] = useState(false);
+  const dispatch = useDispatch();
 
   const fetchEnrichedSite = async () => {
-    if (isLoading || enrichedSite) return; // Avoid duplicate requests
-    
+    if (isLoading || enrichedSite) return;
+
     setIsLoading(true);
     setError(null);
-    
+
     try {
-      const detailed = await getCampsiteById(site.id);
-      if (detailed) {
-        setEnrichedSite(detailed);
+      const resultAction = await dispatch(fetchCampsiteById(site.id) as any);
+      if (fetchCampsiteById.fulfilled.match(resultAction)) {
+        setEnrichedSite(resultAction.payload);
       } else {
         setError("Campsite details not found");
       }

--- a/packages/client/src/components/MapView/MapView.test.tsx
+++ b/packages/client/src/components/MapView/MapView.test.tsx
@@ -131,6 +131,5 @@ describe("MapView", () => {
       expect(screen.getByTestId("person-marker")).toBeInTheDocument();
     });
     expect(screen.getByTestId("person-tooltip")).toHaveTextContent(/You are here/i);
-    expect(screen.getByTestId("person-popup")).toHaveTextContent(/You are here/i);
   });
 });

--- a/packages/client/src/components/MapView/MapView.tsx
+++ b/packages/client/src/components/MapView/MapView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo, useCallback, Suspense } from "react";
-import { MapContainer, TileLayer, Marker, Popup, Tooltip } from "react-leaflet";
+import { MapContainer, TileLayer, Marker, Tooltip } from "react-leaflet";
 import L from "leaflet";
 import "./MapView.css";
 import type { Campsite } from '../../types/Campsite';
@@ -73,7 +73,6 @@ const MapView: React.FC<MapViewProps> = ({ campsites }) => {
             {campsiteMarkers}
             {currentPosition && (
               <Marker position={currentPosition} icon={personIcon}>
-                <Popup>You are here</Popup>
                 <Tooltip direction="top" offset={[0, -40]} opacity={1} permanent={false} sticky>
                   You are here
                 </Tooltip>

--- a/packages/client/src/store/campsiteSlice.test.ts
+++ b/packages/client/src/store/campsiteSlice.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import reducer, {
   fetchCampsites,
+  fetchCampsiteById,
   clearError,
   selectCampsites,
   selectLoading,
@@ -104,6 +105,30 @@ describe('campsiteSlice', () => {
 
       it('handles rejected', () => {
         const action = { type: fetchCampsites.rejected.type, payload: 'Error' };
+        const state = reducer({ ...initialState, loading: true }, action);
+        expect(state.loading).toBe(false);
+        expect(state.error).toBe('Error');
+      });
+    });
+
+    describe('fetchCampsiteById', () => {
+      it('handles pending', () => {
+        const action = { type: fetchCampsiteById.pending.type };
+        const state = reducer(initialState, action);
+        expect(state.loading).toBe(true);
+        expect(state.error).toBeNull();
+      });
+
+      it('handles fulfilled', () => {
+        const action = { type: fetchCampsiteById.fulfilled.type, payload: mockCampsite };
+        const state = reducer({ ...initialState, loading: true }, action);
+        expect(state.loading).toBe(false);
+        expect(state.campsites).toContain(mockCampsite);
+        expect(state.error).toBeNull();
+      });
+
+      it('handles rejected', () => {
+        const action = { type: fetchCampsiteById.rejected.type, payload: 'Error' };
         const state = reducer({ ...initialState, loading: true }, action);
         expect(state.loading).toBe(false);
         expect(state.error).toBe('Error');

--- a/packages/server/artillery.yml
+++ b/packages/server/artillery.yml
@@ -10,3 +10,8 @@ scenarios:
   - flow:
       - get:
           url: "/api/v1/campsites"
+          capture:
+            - json: "$.id"
+              as: "campsiteId"
+      - get:
+          url: "/api/v1/campsites/{{ campsiteId }}"


### PR DESCRIPTION
## Background

+ Refactoring the getCampsiteById to be in the redux store and use caching/local storage
+ Minor CSS changes